### PR TITLE
Remove unnecessary clippy attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::non_ascii_literal)]
-
 mod checkbox;
 mod input;
 mod language;


### PR DESCRIPTION
`#![allow(clippy::non_ascii_literal)]`는 필요없어서 삭제합니다.