### PR TITLE
Add markdownlint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       run: cargo fmt -- --check
     - name: Clippy
       run: cargo clippy -- -D warnings -W clippy::pedantic
+    - name: markdownlint
+      uses: articulate/actions-markdownlint@v1
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+---
+MD024:
+  siblings_only: true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# frontary
+# Frontary
+
 Reusable HTML components using Yew


### PR DESCRIPTION
브랜치를 push할 때마다 마크다운 파일의 포맷이 제대로 되어있는지 검사합니다.