### PR TITLE
Remove unnecessary `#allow(clippy::option_if_let_else)`

### DIFF
--- a/src/input/component.rs
+++ b/src/input/component.rs
@@ -505,7 +505,6 @@ where
                 }
             }
             Message::InputTagGroup(id, input_data) => {
-                #[allow(clippy::option_if_let_else)]
                 let (new, edit, delete) = if let Some(buffer) = self.tag_buffer.get(&id) {
                     let (empty, new, edit, delete) = if let Ok(buffer) = buffer.try_borrow_mut() {
                         if let Ok(mut item) = input_data.try_borrow_mut() {

--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -144,8 +144,6 @@ where
                     ctx.props().selected.try_borrow_mut(),
                     ctx.props().list.try_borrow(),
                 ) {
-                    #[allow(clippy::option_if_let_else)]
-                    // can't use `map_or_else` since `*sel` is used in the closure
                     if let Some(selected) = sel.as_mut() {
                         match ctx.props().kind {
                             Kind::Multi => {


### PR DESCRIPTION
불필요한 `#allow(clippy::option_if_let_else)`를 삭제합니다.