### PR TITLE
Use `PhantomData` to use generic in associated type

### DIFF
--- a/src/input/component.rs
+++ b/src/input/component.rs
@@ -12,9 +12,9 @@ use gloo_file::{
     File,
 };
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -49,13 +49,7 @@ pub enum InputSecondId {
     Edit(String),
 }
 
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
-
+pub struct Model<T> {
     pub(super) radio_buffer: HashMap<usize, Rc<RefCell<String>>>,
     pub(super) host_network_buffer: HashMap<usize, Rc<RefCell<InputHostNetworkGroup>>>,
     pub(super) select_searchable_buffer: HashMap<usize, Rc<RefCell<Option<HashSet<String>>>>>,
@@ -76,6 +70,8 @@ where
     file_reader: Option<FileReader>,
 
     pub(super) rerender_serial_host_network: u64,
+
+    phantom: PhantomData<T>,
 }
 
 impl<T> PartialEq for Model<T>
@@ -102,14 +98,9 @@ where
     }
 }
 
-impl<T> Clone for Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
+impl<T> Clone for Model<T> {
     fn clone(&self) -> Self {
         Self {
-            _dummy: None,
             radio_buffer: self.radio_buffer.clone(),
             host_network_buffer: self.host_network_buffer.clone(),
             select_searchable_buffer: self.select_searchable_buffer.clone(),
@@ -126,6 +117,7 @@ where
             file_content: self.file_content.clone(),
             file_reader: None,
             rerender_serial_host_network: self.rerender_serial_host_network,
+            phantom: PhantomData,
         }
     }
 }
@@ -295,7 +287,6 @@ where
 
     fn create(ctx: &Context<Self>) -> Self {
         let mut s = Self {
-            _dummy: None,
             radio_buffer: HashMap::new(),
             host_network_buffer: HashMap::new(),
             select_searchable_buffer: HashMap::new(),
@@ -316,6 +307,8 @@ where
             file_reader: None,
 
             rerender_serial_host_network: 0,
+
+            phantom: PhantomData,
         };
         Self::prepare_nic(ctx);
         s.prepare_buffer(ctx);

--- a/src/input/host_network.rs
+++ b/src/input/host_network.rs
@@ -2,8 +2,8 @@ use crate::{
     language::Language, parse_host_network, text, HostNetwork, InputHostNetworkGroup, Texts,
 };
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, KeyboardEvent};
 use yew::{events::InputEvent, html, Component, Context, Html, Properties, TargetCast};
@@ -22,15 +22,11 @@ enum ItemType {
 }
 
 #[derive(PartialEq)]
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
     input: String,
     message: Option<&'static str>,
     view_order: Vec<ItemType>,
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -100,10 +96,10 @@ where
 
     fn create(ctx: &Context<Self>) -> Self {
         let mut s = Self {
-            _dummy: None,
             input: String::new(),
             message: None,
             view_order: Vec::new(),
+            phantom: PhantomData,
         };
         s.init_view_order(ctx);
         s

--- a/src/input/tag.rs
+++ b/src/input/tag.rs
@@ -2,20 +2,15 @@ use crate::{
     language::Language, text, toggle_visibility, visible_tag_select, InputTagGroup, Texts,
 };
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, KeyboardEvent};
 use yew::{events::InputEvent, html, Component, Context, Html, Properties, TargetCast};
 
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
     prev_list: Rc<HashMap<String, String>>,
     input: String,
     message: Option<&'static str>,
@@ -25,6 +20,7 @@ where
     edit: Option<String>, // String = key of tag
     edit_message: Option<&'static str>,
     input_edit: String,
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -77,7 +73,6 @@ where
 
     fn create(ctx: &Context<Self>) -> Self {
         let mut s = Self {
-            _dummy: None,
             prev_list: ctx.props().prev_list.clone(),
             input: String::new(),
             message: None,
@@ -87,6 +82,7 @@ where
             edit: None,
             edit_message: None,
             input_edit: String::new(),
+            phantom: PhantomData,
         };
         s.init_view_order(ctx);
         s.reset_search_list(ctx);

--- a/src/list/whole/component.rs
+++ b/src/list/whole/component.rs
@@ -7,9 +7,9 @@ use crate::{
     SelectMiniKind, SortStatus, Texts, ViewString,
 };
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -26,13 +26,7 @@ pub(super) enum ViewInputStatus {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
-
+pub struct Model<T> {
     data_cache: HashMap<String, ListItem>, // to check `data` being changed
     id_cache: String,                      // to check `id` being changed
     // `pages_info` is not just a cache. This is altered by this `Model`.
@@ -51,6 +45,8 @@ where
     pub(super) view_input_status: ViewInputStatus,
     pub(super) more_action: Rc<RefCell<Option<MoreAction>>>,
     pub(super) sort_list_kind: Rc<RefCell<Option<SortListKind>>>,
+
+    phantom: PhantomData<T>,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -164,7 +160,6 @@ where
 
     fn create(ctx: &Context<Self>) -> Self {
         let mut s = Self {
-            _dummy: None,
             data_cache: (*ctx.props().data).clone(),
             id_cache: ctx.props().id.clone(),
             pages_info: ctx.props().pages_info.try_borrow().ok().map(|info| *info),
@@ -181,6 +176,8 @@ where
             view_input_status: ViewInputStatus::None,
             more_action: Rc::new(RefCell::new(None)),
             sort_list_kind: Rc::new(RefCell::new(None)),
+
+            phantom: PhantomData,
         };
         s.initiate_pages_info(ctx);
         s.reset_sort_second_layer(ctx);

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -1,6 +1,6 @@
 use crate::{language::Language, text, Texts};
 use json_gettext::get_text;
-use std::rc::Rc;
+use std::{marker::PhantomData, rc::Rc};
 use yew::{classes, html, Component, Context, Html, Properties};
 
 const MAX_HEIGHT: u32 = 700;
@@ -58,12 +58,8 @@ where
     pub parent_cancel_message: T::Message,
 }
 
-pub struct Model<T>
-where
-    T: Clone + Component,
-    <T as Component>::Message: Clone,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
+    phantom: PhantomData<T>,
 }
 
 impl<T> Component for Model<T>
@@ -75,7 +71,9 @@ where
     type Properties = Props<T>;
 
     fn create(_ctx: &Context<Self>) -> Self {
-        Self { _dummy: None }
+        Self {
+            phantom: PhantomData,
+        }
     }
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,8 +1,8 @@
 use crate::{language::Language, text, Texts};
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::{cell::RefCell, marker::PhantomData};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, KeyboardEvent};
 use yew::{events::InputEvent, html, Component, Context, Html, Properties};
@@ -59,13 +59,9 @@ where
     pub input: bool,
 }
 
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
     go_to_page: usize,
+    phantom: PhantomData<T>,
 }
 
 impl<T> Component for Model<T>
@@ -78,8 +74,8 @@ where
 
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
-            _dummy: None,
             go_to_page: 0,
+            phantom: PhantomData,
         }
     }
 

--- a/src/radio.rs
+++ b/src/radio.rs
@@ -1,7 +1,7 @@
 use crate::{language::Language, text, Texts, ViewString};
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(PartialEq, Eq)]
@@ -9,12 +9,8 @@ pub enum Message {
     ClickItem(usize),
 }
 
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -47,7 +43,9 @@ where
     type Properties = Props<T>;
 
     fn create(ctx: &Context<Self>) -> Self {
-        let s = Self { _dummy: None };
+        let s = Self {
+            phantom: PhantomData,
+        };
         if let Some(value) = ctx.props().default_value.as_ref() {
             if let Ok(mut selected) = ctx.props().selected_value.try_borrow_mut() {
                 *selected = value.clone();

--- a/src/radio_separate.rs
+++ b/src/radio_separate.rs
@@ -1,7 +1,7 @@
 use crate::{language::Language, text, Texts, ViewString};
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -9,12 +9,8 @@ pub enum Message {
     ClickItem,
 }
 
-pub struct Model<T>
-where
-    T: Clone + Component,
-    <T as Component>::Message: Clone,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone, Properties)]
@@ -51,7 +47,9 @@ where
     type Properties = Props<T>;
 
     fn create(_ctx: &Context<Self>) -> Self {
-        Self { _dummy: None }
+        Self {
+            phantom: PhantomData,
+        }
     }
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {

--- a/src/select/mini.rs
+++ b/src/select/mini.rs
@@ -1,20 +1,15 @@
 use crate::{language::Language, text, toggle_visibility, Texts, ViewString};
 use gloo_events::EventListener;
 use json_gettext::get_text;
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use web_sys::{Event, HtmlElement};
 use yew::{classes, html, Component, Context, Html, NodeRef, Properties};
 
-pub struct Model<T, U>
-where
-    T: Copy + Clone + PartialEq + 'static,
-    U: Clone + Component + PartialEq,
-    <U as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<(T, U)>,
+pub struct Model<T, U> {
     click_listener: Option<EventListener>,
     click_count: usize,
+    phantom: PhantomData<(T, U)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -98,9 +93,9 @@ where
 
     fn create(ctx: &Context<Self>) -> Self {
         let s = Self {
-            _dummy: None,
             click_listener: None,
             click_count: 0,
+            phantom: PhantomData,
         };
         if let Some(value) = ctx.props().default_value {
             if let Ok(mut selected) = ctx.props().selected_value.try_borrow_mut() {

--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 use json_gettext::get_text;
 use num_traits::ToPrimitive;
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::{cell::RefCell, marker::PhantomData};
 use wasm_bindgen::JsCast;
 use web_sys::HtmlInputElement;
 use yew::{events::InputEvent, html, Component, Context, Html, Properties};
@@ -18,14 +18,10 @@ pub enum Kind {
 }
 
 #[derive(Clone)]
-pub struct Model<T>
-where
-    T: Clone + Component,
-    <T as Component>::Message: Clone,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
     search_result: Option<Vec<usize>>,
     search_text: String,
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone)]
@@ -80,9 +76,9 @@ where
 
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
-            _dummy: None,
             search_result: None,
             search_text: String::new(),
+            phantom: PhantomData,
         }
     }
 

--- a/src/tab_menu.rs
+++ b/src/tab_menu.rs
@@ -1,6 +1,6 @@
 use crate::{language::Language, text, Texts};
 use json_gettext::get_text;
-use std::rc::Rc;
+use std::{marker::PhantomData, rc::Rc};
 use yew::{classes, html, Component, Context, Html, Properties};
 
 pub enum Message {
@@ -11,12 +11,8 @@ const DEFAULT_FULL_WIDTH: u32 = 1080;
 const DEFAULT_ITEM_WIDTH: u32 = 120;
 const MAX_ITEM_WIDTH: u32 = 240;
 
-pub struct Model<T>
-where
-    T: Clone + Component + PartialEq,
-    <T as Component>::Message: Clone + PartialEq,
-{
-    _dummy: Option<T>,
+pub struct Model<T> {
+    phantom: PhantomData<T>,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -46,7 +42,9 @@ where
     type Properties = Props<T>;
 
     fn create(_ctx: &Context<Self>) -> Self {
-        Self { _dummy: None }
+        Self {
+            phantom: PhantomData,
+        }
     }
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {


### PR DESCRIPTION
[`PhantomData`](https://doc.rust-lang.org/std/marker/struct.PhantomData.html)가 원래 이런 목적으로 쓰도록 만들어진 거라서 메모리를 소모하지 않습니다.