### PR TITLE
Remove unnecessary memory allocations

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -38,8 +38,8 @@ impl HostNetworkGroupTrait for InputHostNetworkGroup {
     fn networks(&self) -> &[String] {
         &self.networks
     }
-    fn ranges(&self) -> Vec<IpRange> {
-        self.ranges.clone()
+    fn ranges(&self) -> &[IpRange] {
+        &self.ranges
     }
 }
 

--- a/src/input/component.rs
+++ b/src/input/component.rs
@@ -528,9 +528,9 @@ where
                 if let Some(buffer) = self.select_searchable_buffer.get(&id) {
                     let empty = if let Ok(buffer) = buffer.try_borrow() {
                         if let Some(buffer) = buffer.as_ref() {
-                            let selected = buffer.iter().map(Clone::clone).collect::<Vec<String>>();
+                            let selected = buffer.iter().map(Clone::clone).next();
                             if let Ok(mut item) = input_data.try_borrow_mut() {
-                                *item = InputItem::SelectSingle(selected.first().cloned());
+                                *item = InputItem::SelectSingle(selected);
                             }
                             buffer.is_empty()
                         } else if let Ok(mut item) = input_data.try_borrow_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ pub trait HostNetworkGroupTrait {
                 return false;
             }
         }
-        for r in &self.ranges() {
+        for r in self.ranges() {
             if !r.is_valid() {
                 return false;
             }
@@ -364,8 +364,7 @@ pub trait HostNetworkGroupTrait {
         for network in self.networks() {
             elems.push(network.clone());
         }
-        let ranges: Vec<String> = self.ranges().iter().map(ToString::to_string).collect();
-        for range in &ranges {
+        for range in self.ranges().iter().map(ToString::to_string) {
             elems.push(range.clone());
         }
         elems
@@ -373,7 +372,7 @@ pub trait HostNetworkGroupTrait {
 
     fn hosts(&self) -> &[String];
     fn networks(&self) -> &[String];
-    fn ranges(&self) -> Vec<IpRange>;
+    fn ranges(&self) -> &[IpRange];
 }
 
 pub fn sort_hosts(hosts: &mut Vec<String>) {

--- a/src/list.rs
+++ b/src/list.rs
@@ -39,16 +39,8 @@ impl ToString for Column {
             Self::Text(d) => d.to_string(),
             Self::HostNetworkGroup(d) => d.join(","),
             Self::SelectSingle(d) => d.as_ref().map_or_else(String::new, |d| d.1.clone()),
-            Self::SelectMultiple(d) => d
-                .values()
-                .map(Clone::clone)
-                .collect::<Vec<String>>()
-                .join(","),
-            Self::Tag(d) => d
-                .iter()
-                .map(Clone::clone)
-                .collect::<Vec<String>>()
-                .join(","),
+            Self::SelectMultiple(d) => d.values().map(String::as_str).collect::<Vec<_>>().join(","),
+            Self::Tag(d) => d.iter().map(String::as_str).collect::<Vec<_>>().join(","),
             Self::Unsigned32(d) => d.map_or_else(String::new, |d| d.to_string()),
             Self::Float64(d) => d.map_or_else(String::new, |d| d.to_string()),
             Self::Percentage(f, d) => f.map_or_else(String::new, |f| {

--- a/src/list/whole/view.rs
+++ b/src/list/whole/view.rs
@@ -79,7 +79,7 @@ where
                                 let first = sum_cols;
                                 sum_cols += cols.len();
                                 let style = if let ColWidths::Pixel(cols) = cols {
-                                    format!("width: {}px;", cols.iter().filter_map(Clone::clone).collect::<Vec<u32>>().iter().sum::<u32>())
+                                    format!("width: {}px;", cols.iter().filter_map(Clone::clone).sum::<u32>())
                                 } else {
                                     "width: 100%;".to_string()
                                 };
@@ -331,7 +331,7 @@ where
                                                                 let first = sum_cols;
                                                                 sum_cols += cols.len();
                                                                 let style = if let ColWidths::Pixel(cols) = cols {
-                                                                    format!("width: {}px;", cols.iter().filter_map(Clone::clone).collect::<Vec<u32>>().iter().sum::<u32>())
+                                                                    format!("width: {}px;", cols.iter().filter_map(Clone::clone).sum::<u32>())
                                                                 } else {
                                                                     "width: 100%;".to_string()
                                                                 };
@@ -458,12 +458,7 @@ where
         match widths {
             ColWidths::Pixel(widths) => Some(
                 ctx.props().display_info.width_full
-                    - widths
-                        .iter()
-                        .filter_map(Clone::clone)
-                        .collect::<Vec<u32>>()
-                        .iter()
-                        .sum::<u32>(),
+                    - widths.iter().filter_map(Clone::clone).sum::<u32>(),
             ),
             ColWidths::Ratio(_) => None,
         }


### PR DESCRIPTION
`collect::<Vec<_>>`, `clone`, `to_string` 등으로 인해 불필요하게 메모리를 할당하고 있는 부분을 메모리를 할당하지 않는 코드로 대체합니다.