### PR TITLE
Use `AttrValue` rather than `String` in properties

### DIFF
--- a/src/input/component.rs
+++ b/src/input/component.rs
@@ -16,7 +16,7 @@ use json_gettext::get_text;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
-use yew::{html, Component, Context, Html, Properties};
+use yew::{html, virtual_dom::AttrValue, Component, Context, Html, Properties};
 
 #[derive(Clone, Copy, PartialEq)]
 pub(super) enum InvalidMessage {
@@ -341,7 +341,7 @@ where
 
     pub data: Rc<HashMap<String, ListItem>>,
     #[prop_or(None)]
-    pub input_id: Option<String>, // Some: Edit, None: Add
+    pub input_id: Option<AttrValue>, // Some: Edit, None: Add
     #[prop_or(None)]
     pub input_second_id: Option<InputSecondId>,
 

--- a/src/list/whole/component.rs
+++ b/src/list/whole/component.rs
@@ -10,7 +10,7 @@ use json_gettext::get_text;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
-use yew::{html, Component, Context, Html, Properties};
+use yew::{html, virtual_dom::AttrValue, Component, Context, Html, Properties};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SortColumn {
@@ -99,7 +99,7 @@ where
     pub language: Language,
 
     // id:: 1st layer: customer/network, 2nd layer: customer-{item's id}
-    pub id: String,
+    pub id: AttrValue,
     pub title: &'static str,
     #[prop_or(None)]
     pub title_second: Option<&'static str>,
@@ -168,7 +168,7 @@ where
     fn create(ctx: &Context<Self>) -> Self {
         let mut s = Self {
             data_cache: (*ctx.props().data).clone(),
-            id_cache: ctx.props().id.clone(),
+            id_cache: ctx.props().id.as_ref().into(),
             pages_info: ctx.props().pages_info.try_borrow().ok().map(|info| *info),
             check_status_second: ctx.props().check_status_second.clone(),
 
@@ -197,7 +197,7 @@ where
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
         // even if the page or sort changes in Flat or LayeredFirst, this `change` is not called. Instead `update` is called.
         let data_changed = self.data_cache != *ctx.props().data;
-        let id_changed = self.id_cache != ctx.props().id;
+        let id_changed = self.id_cache != ctx.props().id.as_ref();
 
         let sort_changed = self.sort != ctx.props().sort;
         if self.data_cache.len() < ctx.props().data.len() {
@@ -323,7 +323,7 @@ where
         }
 
         if id_changed {
-            self.id_cache = ctx.props().id.clone();
+            self.id_cache = ctx.props().id.as_ref().into();
         }
         if data_changed {
             self.data_cache = (*ctx.props().data).clone();

--- a/src/radio.rs
+++ b/src/radio.rs
@@ -2,6 +2,7 @@ use crate::{language::Language, text, Texts, ViewString};
 use json_gettext::get_text;
 use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
+use yew::virtual_dom::AttrValue;
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(PartialEq, Eq)]
@@ -26,7 +27,7 @@ where
     pub list: Rc<Vec<ViewString>>,
     pub candidate_values: Rc<Vec<String>>,
     #[prop_or(None)]
-    pub default_value: Option<String>,
+    pub default_value: Option<AttrValue>,
     pub selected_value: Rc<RefCell<String>>,
     #[prop_or(None)]
     pub width_item: Option<u32>,
@@ -48,7 +49,7 @@ where
         };
         if let Some(value) = ctx.props().default_value.as_ref() {
             if let Ok(mut selected) = ctx.props().selected_value.try_borrow_mut() {
-                *selected = value.clone();
+                *selected = value.as_ref().into();
             }
         }
         s

--- a/src/select/complex/component.rs
+++ b/src/select/complex/component.rs
@@ -10,6 +10,7 @@ use std::collections::{
     HashMap, HashSet,
 };
 use std::rc::Rc;
+use yew::virtual_dom::AttrValue;
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -57,13 +58,13 @@ pub struct Props {
     pub language: Language,
     #[prop_or(Kind::Basic)]
     pub kind: Kind,
-    pub id: String,
-    pub title: String,
-    pub empty_msg: String,
+    pub id: AttrValue,
+    pub title: AttrValue,
+    pub empty_msg: AttrValue,
     pub top_width: u32,
     #[prop_or(DEFAULT_POP_WIDTH)]
     pub pop_width: u32,
-    pub font: String,
+    pub font: AttrValue,
     pub list: Rc<RefCell<Vec<Item>>>,
     pub selected: Rc<ComplexSelection>,
     #[prop_or(true)]

--- a/src/select/mini.rs
+++ b/src/select/mini.rs
@@ -4,6 +4,7 @@ use json_gettext::get_text;
 use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
 use web_sys::{Event, HtmlElement};
+use yew::virtual_dom::AttrValue;
 use yew::{classes, html, Component, Context, Html, NodeRef, Properties};
 
 pub struct Model<T, U> {
@@ -51,8 +52,8 @@ where
     #[prop_or(true)]
     pub active: bool,
     #[prop_or(None)]
-    pub deactive_class_suffix: Option<String>,
-    pub id: String,
+    pub deactive_class_suffix: Option<AttrValue>,
+    pub id: AttrValue,
     pub list: Rc<Vec<ViewString>>,
     pub candidate_values: Rc<Vec<T>>,
     #[prop_or(None)]
@@ -75,12 +76,12 @@ where
     #[prop_or(false)]
     pub list_align_center: bool,
     pub kind: Kind,
-    #[prop_or(DEFAULT_BG_COLOR.to_string())]
-    pub top_bg_color: String,
-    #[prop_or(DEFAULT_VALUE_TEXT_COLOR.to_string())]
-    pub value_text_color: String,
-    #[prop_or(DEFAULT_LIST_TEXT_COLOR.to_string())]
-    pub list_text_color: String,
+    #[prop_or(DEFAULT_BG_COLOR.into())]
+    pub top_bg_color: AttrValue,
+    #[prop_or(DEFAULT_VALUE_TEXT_COLOR.into())]
+    pub value_text_color: AttrValue,
+    #[prop_or(DEFAULT_LIST_TEXT_COLOR.into())]
+    pub list_text_color: AttrValue,
 }
 
 impl<T, U> Component for Model<T, U>
@@ -351,7 +352,7 @@ where
         let suffix = if ctx.props().active {
             String::new()
         } else if let Some(suffix) = ctx.props().deactive_class_suffix.as_ref() {
-            suffix.clone()
+            suffix.as_ref().into()
         } else {
             String::new()
         };

--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
 use wasm_bindgen::JsCast;
 use web_sys::HtmlInputElement;
+use yew::virtual_dom::AttrValue;
 use yew::{events::InputEvent, html, Component, Context, Html, Properties};
 
 const DEFAULT_FONT: &str = "13px 'Spoqa Han Sans Neo'";
@@ -48,18 +49,18 @@ where
 {
     pub txt: Texts,
     pub language: Language,
-    pub id: String,
+    pub id: AttrValue,
     pub kind: Kind,
-    pub title: String,
-    pub empty_msg: String,
+    pub title: AttrValue,
+    pub empty_msg: AttrValue,
     pub top_width: u32,
     #[prop_or(DEFAULT_MAX_WIDTH)]
     pub max_width: u32,
     pub max_height: u32,
     #[prop_or(true)]
     pub align_left: bool,
-    #[prop_or(DEFAULT_FONT.to_string())]
-    pub font: String,
+    #[prop_or(DEFAULT_FONT.into())]
+    pub font: AttrValue,
     pub list: Rc<RefCell<Vec<Item>>>,
     pub selected: Rc<RefCell<Option<HashSet<String>>>>,
     #[prop_or(false)]

--- a/src/select/vec_searchable.rs
+++ b/src/select/vec_searchable.rs
@@ -3,6 +3,7 @@ use crate::{language::Language, Item, SelectSearchable, SelectSearchableKind, Te
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::{cell::RefCell, marker::PhantomData};
+use yew::virtual_dom::AttrValue;
 use yew::{html, Component, Context, Html, Properties};
 
 #[derive(Clone, PartialEq, Eq)]
@@ -20,7 +21,7 @@ where
 {
     pub txt: Texts,
     pub language: Language,
-    pub id: String,
+    pub id: AttrValue,
     pub title: Vec<String>,
     pub kind_last: SelectSearchableKind,
     pub empty_msg: Vec<String>,


### PR DESCRIPTION
From Yew documentation:

String can be expensive to clone. Cloning is often needed when the prop value is used with hooks and callbacks. AttrValue is either a reference-counted string (Rc<str>) or a &'static str, thus very cheap to clone.