### PR TITLE
Turn off the default features of chrono for the security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Make multiple `<Tag>`s available at the same time without `<Input>`.
 
+### Security
+
+- Turned off the default features of chrono that might casue SEGFAULT. See
+  [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071)
+  for details.
+
 ## [0.4.0] - 2023-01-24
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test = []
 [dependencies]
 anyhow = "1"
 bincode = "1"
-chrono = { version = "0.4", features = ["serde", "wasmbind"] }
+chrono = { version = "0.4", default_features = false, features = ["serde", "wasmbind"] }
 data-encoding = "2.3"
 gloo-events = "0.1"
 gloo-file = "0.2"


### PR DESCRIPTION
While bumping version, I think it's better to apply this to the version.