### PR TITLE
태그 수정 클릭 시 입력 창이 닫히는 문제 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2023-04-19
+
+### Fixed
+
+- Fix a bug where tag area gets hidden when edit-related icons are clicked.
+
 ## [0.5.0] - 2023-03-28
 
 ### Changed
@@ -60,6 +66,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[0.5.1]: https://github.com/aicers/frontary/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/aicers/frontary/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/aicers/frontary/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/aicers/frontary/compare/0.3.0...0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontary"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 publish = false
 

--- a/src/input/tag.rs
+++ b/src/input/tag.rs
@@ -208,7 +208,9 @@ where
                     }
                     return false;
                 }
-                _ => {}
+                _ => {
+                    return false;
+                }
             },
             Message::SelectTag(key) => {
                 let send_msg = if let Ok(mut data) = ctx.props().input_data.try_borrow_mut() {
@@ -468,7 +470,7 @@ where
                             <div class={class}>
                                 <div class="tag-group-input-select-item">
                                     <div class="tag-group-input-select-item-text" onclick={ onclick_item(k.clone()) }>
-                                    { v.clone() }
+                                        { v.clone() }
                                     </div>
                                     <img src="/frontary/tag-select-bar.png" class="tag-select-bar" />
                                     <img src="/frontary/tag-select-edit.png" class="tag-select-edit" onclick={ onclick_edit(k.clone()) } />

--- a/static/frontary/custom-select.js
+++ b/static/frontary/custom-select.js
@@ -51,7 +51,9 @@ export function visible_tag_select(id) {
 }
 
 function close_custom_select(elmnt) {
-    if (elmnt.target.className == "tag-select-edit" || elmnt.target.className == "tag-select-edit-done") {
+    if (elmnt.target.className == "tag-select-edit"
+        || elmnt.target.className == "tag-select-edit-done"
+        || elmnt.target.className == "tag-input-close") {
         return;
     }
 

--- a/static/frontary/custom-select.js
+++ b/static/frontary/custom-select.js
@@ -51,6 +51,10 @@ export function visible_tag_select(id) {
 }
 
 function close_custom_select(elmnt) {
+    if (elmnt.target.className == "tag-select-edit" || elmnt.target.className == "tag-select-edit-done") {
+        return;
+    }
+
     // HIGHLIGHT: in case when elmnt has been removed after it was clicked.
     if (elmnt.target.parentNode == null) return;
 


### PR DESCRIPTION
클릭된 element를 감지하고 그 element가 지정된 다른 element의 자손인지를 확인하여 자손이라면 창을 안 닫도록 자바스크립트 코드를 만들었고, 그동안 그게 잘 동작하였는데, 이상하게도 특정 element만 자손으로 인식이 안 되는 현상이 발생함.

그 element를 우선 먼저 확인하도록 하였음.