### PR TITLE
Fix the wrong path to delete-x.png caused by typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fixed the wrong directory of delete-x.png file from `frotary` to `frontary` in `theme.css`.
+- Fixed the wrong directory of delete-x.png file from `frotary`
+  to `frontary` in `theme.css`.
 
 ## [0.9.0] - 2024-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fixed the wrong path of a png file `/frotary` to `/frontary` in `theme.css`.
+- Fixed the wrong directory of delete-x.png file from `frotary` to `frontary` in `theme.css`.
 
 ## [0.9.0] - 2024-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the wrong path of a png file `/frotary` to `/frontary` in `theme.css`.
+
 ## [0.9.0] - 2024-04-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/frontary/compare/0.9.0...main
 [0.9.0]: https://github.com/aicers/frontary/compare/0.8.2...0.9.0
 [0.8.2]: https://github.com/aicers/frontary/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/aicers/frontary/compare/0.8.0...0.8.1

--- a/static/frontary/theme.css
+++ b/static/frontary/theme.css
@@ -634,7 +634,7 @@ div.complex-select-pop-input-list-delete {
     width: 28px;
     height: 28px;
     float: right;
-    background-image: url('/static/frotary/delete-x.png');
+    background-image: url('/static/frontary/delete-x.png');
     background-size: 24px 24px;
     background-position: 2px 2px;
     background-repeat: no-repeat;


### PR DESCRIPTION
Fix #90 

There is the wrong directory path `frotary`, which results in the browser console error. I fixed it correctly: `frontary`.