### PR TITLE
Add hover styling for MoreActionBasic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added `MoreActionBasic` to `SelectMiniKind` in `SelectMini`.
+- Added correct CSS styling for `MoreActionBasic` for `SelectMini`.
 
 ### Fixed
 

--- a/static/frontary/theme.css
+++ b/static/frontary/theme.css
@@ -709,6 +709,11 @@ td.mini-select-list-down-item:hover {
     cursor: pointer;
 }
 
+td.mini-select-list-down-item-more-action-basic:hover {
+    background-color: #EDEDED;
+    cursor: pointer;
+}
+
 div.mini-select-list-down-item-more-action {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Perviously, when hovering over `MoreActionBasic` there would be no CSS styling. This is due to the adding a custom CSS styling for `MoreActionBasic` not having hover also created. This PR addresses that problem by adding the hover styling for `MoreActionBasic`.

Closes : #107 ;