### PR TITLE
Add `Svg` for fetching and displaying SVG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `MoreActionBasic` to `SelectMiniKind` in `SelectMini`.
 - Added correct CSS styling for `MoreActionBasic` for `SelectMini`.
 - Added Clumit components: `Radio`, `CheckBox`, `TabMenu`, `Modal`.
+- Added `Svg` to fetch and display a SVG file.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pumpkin-light = []
 [dependencies]
 anyhow = "1"
 bincode = "1"
-chrono = { version = ">=0.4.35", default_features = false, features = [
+chrono = { version = ">=0.4.35", default-features = false, features = [
     "serde",
     "wasmbind",
 ] }
@@ -22,12 +22,15 @@ gloo-events = "0.2"
 gloo-file = "0.3"
 gloo-storage = "0.3"
 gloo-timers = "0.3"
+gloo-utils = "0.2"
 htmlescape = "0.3"
 ipnet = { version = "2", features = ["serde"] }
 js-sys = "0.3"
 json-gettext = "4"
 num-traits = "0.2"
 passwords = { version = "3", features = ["common-password"] }
+reqwasm = "0.5"
+scraper = "0.19"
 serde = { version = "1", features = ["derive"] }
 strum = "0.26"
 strum_macros = "0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod radio_separate;
 mod select;
 mod sort;
 pub mod static_files;
+mod svg;
 mod tab_menu;
 mod text_input;
 
@@ -59,6 +60,7 @@ pub use crate::select::mini::{Kind as SelectMiniKind, Model as SelectMini};
 pub use crate::select::searchable::{Kind as SelectSearchableKind, Model as SelectSearchable};
 pub use crate::select::vec_searchable::Model as VecSelect;
 pub use crate::sort::{Model as Sort, Status as SortStatus};
+pub use crate::svg::Model as Svg;
 pub use crate::tab_menu::Model as TabMenu;
 pub use crate::text_input::Model as TextInput;
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,0 +1,193 @@
+use anyhow::{anyhow, Result};
+use gloo_utils::{document, window};
+use reqwasm::http::Request;
+use scraper::{Html as SHtml, Selector};
+use strum_macros::Display;
+use web_sys::{Element, Node};
+use yew::{html, virtual_dom::AttrValue, Component, Context, Html, Properties};
+
+pub struct Model {
+    svg: Option<String>,
+    error_msg: Option<FetchErrorMessage>,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub path: AttrValue,
+    #[prop_or(None)]
+    pub width: Option<u32>,
+    #[prop_or(None)]
+    pub height: Option<u32>,
+    #[prop_or(None)]
+    pub class: Option<AttrValue>,
+}
+
+pub enum Message {
+    SvgFetched(String),
+    InvalidSvg,
+    HttpNoSucess,
+    ResponseError,
+    QueryError,
+}
+
+#[derive(Display)]
+pub enum FetchErrorMessage {
+    #[strum(serialize = "Invalid SVG format")]
+    InvalidSvg,
+    #[strum(serialize = "HTTP Failure")]
+    HttpNoSucess,
+    #[strum(serialize = "Response Error")]
+    ResponseError,
+    #[strum(serialize = "Query Error")]
+    QueryError,
+}
+
+impl Component for Model {
+    type Message = Message;
+    type Properties = Props;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let s = Self {
+            svg: None,
+            error_msg: None,
+        };
+        Self::fetch(ctx);
+        s
+    }
+
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Message::SvgFetched(svg) => {
+                self.svg = Some(svg);
+                self.error_msg = None;
+            }
+            Message::InvalidSvg => {
+                self.error_msg = Some(FetchErrorMessage::InvalidSvg);
+            }
+            Message::HttpNoSucess => {
+                self.error_msg = Some(FetchErrorMessage::HttpNoSucess);
+            }
+            Message::ResponseError => {
+                self.error_msg = Some(FetchErrorMessage::ResponseError);
+            }
+            Message::QueryError => {
+                self.error_msg = Some(FetchErrorMessage::QueryError);
+            }
+        }
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        if let Some(err_msg) = self.error_msg.as_ref() {
+            html! {
+                if cfg!(feature = "test") {
+                    <div>{ err_msg.to_string() }</div>
+                }
+            }
+        } else if let Some(svg) = self.svg.as_ref() {
+            match Self::element(ctx, svg) {
+                Ok(elem) => {
+                    let node: Node = elem.into();
+                    Html::VRef(node)
+                }
+                Err(e) => {
+                    if cfg!(feature = "test") {
+                        html! {
+                            <div>{ e.to_string() }</div>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+            }
+        } else {
+            html! {}
+        }
+    }
+}
+
+impl Model {
+    fn fetch(ctx: &Context<Self>) {
+        if let Ok(req) = request(ctx.props().path.as_str()) {
+            ctx.link().send_future(async {
+                if let Ok(res) = req.send().await {
+                    if res.ok() {
+                        let svg = res.text().await.unwrap_or_default();
+                        let svg = svg.trim();
+                        if svg.to_lowercase().starts_with("<svg") {
+                            Message::SvgFetched(svg.to_string())
+                        } else {
+                            Message::InvalidSvg
+                        }
+                    } else {
+                        Message::HttpNoSucess
+                    }
+                } else {
+                    Message::ResponseError
+                }
+            });
+        } else {
+            ctx.link().send_message(Message::QueryError);
+        };
+    }
+
+    fn element(ctx: &Context<Self>, svg: &str) -> Result<Element> {
+        let div: Element = document().create_element("div").map_err(|e| {
+            anyhow!(
+                "failed to create a div element: {}",
+                e.as_string().unwrap_or_default()
+            )
+        })?;
+        if let Some(class) = ctx.props().class.as_ref() {
+            div.set_class_name(class);
+        }
+
+        let doc = SHtml::parse_document(svg);
+        let width = select(ctx.props().width, &doc, "width");
+        let height = select(ctx.props().height, &doc, "height");
+
+        if let Some(width) = width {
+            div.set_attribute("width", &width).map_err(|e| {
+                anyhow!(
+                    "failed to set the width attribute: {}",
+                    e.as_string().unwrap_or_default()
+                )
+            })?;
+        }
+        if let Some(height) = height {
+            div.set_attribute("height", &height).map_err(|e| {
+                anyhow!(
+                    "failed to set the height attribute: {}",
+                    e.as_string().unwrap_or_default()
+                )
+            })?;
+        }
+        div.set_inner_html(svg);
+
+        Ok(div)
+    }
+}
+
+fn request(path: &str) -> Result<Request> {
+    let mut uri = window().location().origin().map_err(|e| {
+        anyhow!(
+            "failed to get the origin: {}",
+            e.as_string().unwrap_or_default()
+        )
+    })?;
+    uri.push_str(path);
+    let request = Request::get(&uri);
+    Ok(request)
+}
+
+fn select(user_value: Option<u32>, doc: &SHtml, key: &str) -> Option<String> {
+    user_value.map(|x| x.to_string()).or_else(|| {
+        let select = format!("[{key}]");
+        let select = Selector::parse(&select);
+        select.ok().and_then(move |select| {
+            doc.select(&select)
+                .next()
+                .and_then(|element| element.value().attr(key).map(ToString::to_string))
+        })
+    })
+}


### PR DESCRIPTION
Close #105 

The new component, `Svg`, fetches an SVG file from the server and displays it dynamically. Here are some examples:

When only the path of the SVG file is provided, the `div` element containing the `svg` will have the same width and height as the `svg`.
```Rust
<Svg path="/img/Logo.svg" />
```

When a width and/or height is specified, the `div` will have those dimensions.
```Rust
<Svg path="/img/Logo.svg" width={200} height={100} />
```

A class name for styling can also be given.
```Rust
<Svg path="/img/Logo.svg" class="logo" />
```