### PR TITLE
Modify `radio`, `checkbox` codes to conform to HTML5 standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Added the `role` attribute to the `radio` and `checkbox` elements implemented
+  with `div` tags, which will enhance web accessibility.
+
 ## [0.9.2] - 2024-10-07
 
 ### Added

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -54,7 +54,7 @@ pub fn model(props: &Props) -> Html {
     let style = format!("background-image: url({url});");
 
     html! {
-        <div class="basic-checkbox" style={style}>
+        <div role="checkbox" class="basic-checkbox" style={style}>
         </div>
     }
 }

--- a/src/radio.rs
+++ b/src/radio.rs
@@ -75,7 +75,7 @@ where
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
-            <div class="radio-outer">
+            <div class="radio-outer" role="radiogroup">
             {
                 for ctx.props().list.iter().enumerate().map(|(index, item)| {
                     let checked = if let Ok(selected) = ctx.props().selected_value.try_borrow() {
@@ -100,7 +100,7 @@ where
 
                     html! {
                         <>
-                            <div class="radio-item" onclick={onclick(index)} style={style}>
+                            <div class="radio-item" role="radio" onclick={onclick(index)} style={style}>
                                 <img src={img} class="radio-img" />
                                 {
                                     match item {

--- a/src/radio_separate.rs
+++ b/src/radio_separate.rs
@@ -92,8 +92,8 @@ where
         let onclick = ctx.link().callback(move |_| Message::ClickItem);
 
         html! {
-            <div class="radio-outer">
-                <div class="radio-item" onclick={onclick}>
+            <div class="radio-outer" role="radiogroup">
+                <div role="radio" class="radio-item" onclick={onclick}>
                     <img src={img} class="radio-separate-img" />
                     {
                         match ctx.props().value.as_ref() {


### PR DESCRIPTION
Closes: #110 

I added the `role` attribute to the `radio` and `checkbox` elements implemented with `div` tags. Since we decided not to change the `div` implementation to `input` elements, I aimed to enhance web accessibility by adding only the `role` attribute. 