### PR TITLE
Change `SelectSearchable` height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Adjusted the height of `SelectSearchable` to ensure all items are visible,
+  according to the features.
+
 ## [0.9.3] - 2024-10-16
 
 ### Changed
@@ -207,6 +214,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/frontary/compare/0.9.3...main
 [0.9.3]: https://github.com/aicers/frontary/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/aicers/frontary/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/aicers/frontary/compare/0.9.0...0.9.1

--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -37,7 +37,9 @@ pub enum Message {
     ClickItem(String),
     InputError,
 }
-
+#[cfg(feature = "pumpkin-dark")]
+const ELEM_HEIGHT: u32 = 48;
+#[cfg(not(feature = "pumpkin-dark"))]
 const ELEM_HEIGHT: u32 = 32;
 const DEFAULT_MAX_WIDTH: u32 = 500;
 pub(super) const DEFAULT_SIZED_VALUE: bool = true;
@@ -375,11 +377,19 @@ where
             .map_or(0, |list| list.len())
             .to_u32()
             .expect("> u32::MAX never happens");
-        let height = if ctx.props().kind == Kind::Single {
-            std::cmp::min(list_len * ELEM_HEIGHT + 42, ctx.props().max_height)
+        let extra_height = if ctx.props().kind == Kind::Single {
+            if cfg!(feature = "pumpkin-dark") {
+                67
+            } else {
+                42
+            }
         } else {
-            std::cmp::min(list_len * ELEM_HEIGHT + 80, ctx.props().max_height)
+            80
         };
+        let height = std::cmp::min(
+            list_len * ELEM_HEIGHT + extra_height,
+            ctx.props().max_height,
+        );
         let left = if width > ctx.props().top_width - 8 && !ctx.props().align_left {
             format!("-{}", width - (ctx.props().top_width - 8) + 4)
         } else {


### PR DESCRIPTION
Fixes #159

밑에 스크린샷처럼 변경했습니다.
![Screenshot 2024-10-16 at 3 45 24 PM](https://github.com/user-attachments/assets/5572fc99-e482-4226-a0cb-49fa2f6b703b)

Related https://github.com/aicers/aice-web/issues/682
