### PR TITLE
Simplify `check_input` functions

### DIFF
--- a/src/ip_range_input.rs
+++ b/src/ip_range_input.rs
@@ -141,22 +141,19 @@ impl Model {
 
 fn check_input(input: &str) -> Option<IpRange> {
     if input.contains('~') {
-        input.split_once('~').map_or_else(
-            || None,
-            |(start, end)| {
-                if let (Ok(start), Ok(end)) = (
-                    Ipv4Addr::from_str(start.trim()),
-                    Ipv4Addr::from_str(end.trim()),
-                ) {
-                    (start < end).then_some(IpRange {
-                        start: start.to_string(),
-                        end: end.to_string(),
-                    })
-                } else {
-                    None
-                }
-            },
-        )
+        input.split_once('~').and_then(|(start, end)| {
+            if let (Ok(start), Ok(end)) = (
+                Ipv4Addr::from_str(start.trim()),
+                Ipv4Addr::from_str(end.trim()),
+            ) {
+                (start < end).then_some(IpRange {
+                    start: start.to_string(),
+                    end: end.to_string(),
+                })
+            } else {
+                None
+            }
+        })
     } else {
         Ipv4Addr::from_str(input.trim()).ok().map(|ip| IpRange {
             start: ip.to_string(),

--- a/src/port_range_input.rs
+++ b/src/port_range_input.rs
@@ -146,21 +146,16 @@ impl Model {
 
 fn check_input(input: &str) -> Option<PortRange> {
     if input.contains('~') {
-        input.split_once('~').map_or_else(
-            || None,
-            |(start, end)| {
-                if let (Ok(start), Ok(end)) =
-                    (i64::from_str(start.trim()), i64::from_str(end.trim()))
-                {
-                    (start < end).then_some(PortRange {
-                        start: Some(start),
-                        end: Some(end),
-                    })
-                } else {
-                    None
-                }
-            },
-        )
+        input.split_once('~').and_then(|(start, end)| {
+            if let (Ok(start), Ok(end)) = (i64::from_str(start.trim()), i64::from_str(end.trim())) {
+                (start < end).then_some(PortRange {
+                    start: Some(start),
+                    end: Some(end),
+                })
+            } else {
+                None
+            }
+        })
     } else {
         i64::from_str(input.trim()).ok().map(|port| PortRange {
             start: Some(port),


### PR DESCRIPTION
Simplified the `check_input` functions in `ip_range_input` and `port_range_input` by replacing `map_or_else` with `and_then`.

The logic remains the same, but the code is now more concise. No functional changes are expected from this update.