### PR TITLE
Modify clumit dropdown ui

### DIFF
--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -404,22 +404,29 @@ where
             "4".to_string() // 4 is for left shadow
         };
 
-        let (style, style_inner, style_inner_width, style_inner_width_search) =
-            if cfg!(feature = "pumpkin-dark") {
-                (
-                    format!("height: {height}px;"),
-                    format!("width: 100%; height: {height}px;"),
-                    "width: 100%;".to_string(),
-                    "width: 100%;".to_string(),
-                )
-            } else {
-                (
-                    format!("width: {width}px; height: {height}px; left: {left}px;"),
-                    format!("width: {}px; height: {height}px;", width - 10),
-                    format!("width: {}px;", width - 10),
-                    format!("width: {}px", width - 10 - 28),
-                )
-            };
+        let (
+            style,
+            style_inner,
+            style_inner_width,
+            style_inner_width_search,
+            style_scrollable_table,
+        ) = if cfg!(feature = "pumpkin-dark") {
+            (
+                format!("height: {height}px;"),
+                format!("width: 100%; height: {height}px;"),
+                "width: 100%;".to_string(),
+                "width: 100%;".to_string(),
+                format!("height: {}px;", height - 48),
+            )
+        } else {
+            (
+                format!("width: {width}px; height: {height}px; left: {left}px;"),
+                format!("width: {}px; height: {height}px;", width - 10),
+                format!("width: {}px;", width - 10),
+                format!("width: {}px", width - 10 - 28),
+                String::new(),
+            )
+        };
         let oninput_search = ctx.link().callback(|e: InputEvent| {
             e.target()
                 .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
@@ -503,6 +510,7 @@ where
                             oninput={oninput_search}
                         />
                     </div>
+                    <div class="scrollable-table-wrapper" style={style_scrollable_table}>
                     <div class="searchable-select-list-search-space" style={style_inner_width.clone()}>
                     </div>
                     {
@@ -533,6 +541,7 @@ where
                             html! {}
                         }
                     }
+
                     <table style={style_inner_width}>
                     {
                         if let Some(search_result) = self.search_result.as_ref() {
@@ -617,6 +626,7 @@ where
                         }
                     }
                     </table>
+                    </div>
                 </div>
             </div>
         }

--- a/static/frontary/clumit-theme.css
+++ b/static/frontary/clumit-theme.css
@@ -199,12 +199,10 @@ input[type=text].searchable-select-input-empty-alert {
 div.searchable-select-list-down {
     visibility: hidden;
     margin-top: 3px;
-    padding-left: 5px;
     font-size: 16px;
     color: #4D4D4D;
     position: relative;
     z-index: 199;
-    overflow: auto;
     background-color: #30353A;
     box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);
     border-radius: 8px;
@@ -212,10 +210,11 @@ div.searchable-select-list-down {
 
 div.searchable-select-list-search {
     margin-top: 6px;
+    padding: 8px;
     height: 48px;
     background-image: url('/frontary/clumit-magnifier.svg');
     background-size: 32px 32px;
-    background-position: left 12px top 3px;
+    background-position: 12px 10px;
     background-repeat: no-repeat;
 }
 
@@ -284,6 +283,32 @@ td.searchable-select-list-item-single {
     font-weight: 400;
     line-height: 24px;
     height: 48px;
+}
+
+div.scrollable-table-wrapper {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: #474C55 transparent;
+}
+
+div.scrollable-table-wrapper::-webkit-scrollbar {
+    width: 10px;
+}
+
+div.scrollable-table-wrapper::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+div.scrollable-table-wrapper::-webkit-scrollbar-thumb {
+    background-color: #474C55;
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+
+div.scrollable-table-wrapper::-webkit-scrollbar-thumb:hover {
+    background-color: #5a5f69;
 }
 
 div.complex-select {


### PR DESCRIPTION
Fixes #174

I aimed to ensure consistent scroll behavior across Chrome, Firefox, and Safari. The effect in Chrome and Firefox uses `scrollbar-width: thin` and `scrollbar-color: #474C55 transparent`. Since Safari doesn’t fully support these, I used ::-webkit-scrollbar to match the design. While the interaction differs slightly, the search bar stays fixed, and only the dropdown content scrolls with the same color across browsers.