### PR TITLE
Fix a bug that display the same in multiple inputs

### DIFF
--- a/src/input/config.rs
+++ b/src/input/config.rs
@@ -72,6 +72,8 @@ pub struct SelectMultipleConfig {
     pub preset: Option<Vec<String>>,
 }
 
+/// `Tag` items must belong to the top level of the hierarchy. It cannot be a child of `Checkbox` or
+/// `Radio`, and cannot be an item of `VecSelect` or `Group`.
 #[derive(Clone, PartialEq)]
 pub struct TagConfig {
     pub ess: Essential,

--- a/src/input/item.rs
+++ b/src/input/item.rs
@@ -607,6 +607,10 @@ impl GroupItem {
         self.groups.clone()
     }
 
+    pub fn set_groups(&mut self, groups: Vec<Vec<Rc<RefCell<InputItem>>>>) {
+        self.groups = groups;
+    }
+
     pub fn clear(&mut self) {
         for group in &mut self.groups {
             for item in group {

--- a/src/input/recursive.rs
+++ b/src/input/recursive.rs
@@ -1100,7 +1100,7 @@ where
                                             )))
                                         })
                                         .collect::<Vec<_>>();
-                                    *user = GroupItem::new(vec![new_row]);
+                                    user.set_groups(vec![new_row]);
                                 }
                             }
                             (InputItem::Password(_), InputConfig::Password(_))

--- a/src/input/user_input.rs
+++ b/src/input/user_input.rs
@@ -390,6 +390,9 @@ where
                     } else {
                         html! {
                             <input type="number" class={class} style={style}
+                                // HIGHLIGHT: This must be set to empty string. If not, the previous
+                                // input shows here when another item in the group is added.
+                                value={String::new()}
                                 placeholder={placeholder}
                                 autofocus={autofocus}
                                 oninput={oninput}
@@ -518,6 +521,9 @@ where
                     } else {
                         html! {
                             <input type="number" class={class} style={style}
+                                // HIGHLIGHT: This must be set to empty string. If not, the previous
+                                // input shows here when another item in the group is added.
+                                value={String::new()}
                                 step={step.to_string()}
                                 placeholder={placeholder}
                                 autofocus={autofocus}
@@ -646,6 +652,9 @@ where
                     } else {
                         html! {
                             <input type="number" class={class} style={style}
+                                // HIGHLIGHT: This must be set to empty string. If not, the previous
+                                // input shows here when another item in the group is added.
+                                value={String::new()}
                                 placeholder={placeholder}
                                 autofocus={autofocus}
                                 oninput={oninput}

--- a/src/input/user_input_composite.rs
+++ b/src/input/user_input_composite.rs
@@ -473,47 +473,44 @@ where
                                         html! {
                                             <tr>
                                                 {
-                                                    for items_conf.iter().enumerate().map(|(col_index, each)| {
-                                                        let Some(input_data) = row.get(col_index) else {
-                                                            return html! {};
-                                                        };
+                                                    for row.iter().zip(items_conf.iter()).enumerate().map(|(col_index, (each_item, each_conf))| {
                                                         html! {
                                                             <td class="input-group">
                                                                 <div class="input-group-item-outer">
                                                                 {
-                                                                    match &**each {
+                                                                    match &**each_conf {
                                                                         InputConfig::Text(config) => {
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
-                                                                            self.view_text(ctx, &ess, config.length, config.width, input_data,
+                                                                            self.view_text(ctx, &ess, config.length, config.width, each_item,
                                                                                 Some(&row_rep_index), col_index, false, true)
                                                                         }
                                                                         InputConfig::SelectSingle(config) => {
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
-                                                                            self.view_select_searchable(ctx, false, &ess, config.width, &config.options, input_data,
+                                                                            self.view_select_searchable(ctx, false, &ess, config.width, &config.options, each_item,
                                                                                 Some(&row_rep_index), col_index, 1, true)
                                                                         }
                                                                         InputConfig::VecSelect(config) => {
                                                                             self.view_vec_select(ctx, &config.ess, &config.items_ess_list, config.last, config.full_width, &config.widths, &config.max_widths,
-                                                                                &config.max_heights, &config.map_list, input_data, Some(&row_rep_index), col_index, true)
+                                                                                &config.max_heights, &config.map_list, each_item, Some(&row_rep_index), col_index, true)
                                                                         }
                                                                         InputConfig::Unsigned32(config) => {
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
-                                                                            self.view_unsigned_32(ctx, &ess, config.min, config.max, config.width, input_data,
+                                                                            self.view_unsigned_32(ctx, &ess, config.min, config.max, config.width, each_item,
                                                                                 Some(&row_rep_index), col_index, false, true)
                                                                         }
                                                                         InputConfig::Float64(config) => {
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
-                                                                            self.view_float_64(ctx, &ess, config.step, config.width, input_data,
+                                                                            self.view_float_64(ctx, &ess, config.step, config.width, each_item,
                                                                                 Some(&row_rep_index), col_index, false, true)
                                                                         }
                                                                         InputConfig::Comparison(config) => {
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
-                                                                            self.view_comparison(ctx, &ess, input_data, Some(&row_rep_index), col_index, true)
+                                                                            self.view_comparison(ctx, &ess, each_item, Some(&row_rep_index), col_index, true)
                                                                         }
                                                                         _ => html! {}
                                                                     }


### PR DESCRIPTION
HTML elements such as input should set their value to an empty string at least. If it is unspecified, the value might carry over from the previous input.

Closes #201 