### PR TITLE
Fix Clippy warnings caused by rustc 1.86.0

### DIFF
--- a/src/input/recursive.rs
+++ b/src/input/recursive.rs
@@ -436,7 +436,7 @@ where
                                 && self
                                     .verification_host_network
                                     .get(&this_index)
-                                    .is_some_and(|v| v.map_or(true, |v| v))
+                                    .is_some_and(|&v| v != Some(true))
                         }
                         (InputItem::Nic(n), InputConfig::Nic(_)) => {
                             input_conf.required()
@@ -621,14 +621,14 @@ where
         })
         .collect::<Vec<Vec<Option<bool>>>>();
         for (row_index, row) in empty.iter().enumerate() {
-            let all_empty = row.iter().all(|x| x.map_or(false, |x| x));
+            let all_empty = row.iter().all(|&x| x == Some(true));
             if !all_empty || config.ess.required && row_index == 0 {
                 // HIGHLIGHT: If the entire row is empty, this row will be ignored. Only when more
                 // than one column is not empty, the other elements being empty need to be checked.
                 for ((col_index, data_empty), data_required) in
                     row.iter().enumerate().zip(required.iter())
                 {
-                    if data_empty.map_or(true, |x| x) && *data_required {
+                    if *data_empty != Some(false) && *data_required {
                         self.required_msg.insert(cal_index(
                             Some(&cal_index(Some(base_index), row_index)),
                             col_index,

--- a/src/list.rs
+++ b/src/list.rs
@@ -3,7 +3,7 @@ mod whole;
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt,
+    fmt::{self, Write},
 };
 
 use chrono::{DateTime, Utc};
@@ -195,10 +195,11 @@ impl std::fmt::Display for Column {
             Self::Nic(nics) => {
                 let mut display = String::new();
                 for nic in &nics.nics {
-                    display.push_str(&format!(
+                    write!(
+                        display,
                         "{{{}: {}(interface) {}(gateway)}} ",
                         nic.name, nic.interface, nic.gateway
-                    ));
+                    )?;
                 }
                 write!(formatter, "{display}")
             }

--- a/src/list/whole/component.rs
+++ b/src/list/whole/component.rs
@@ -359,7 +359,7 @@ where
                     if let Ok(mut id) = ctx.props().input_ids.try_borrow_mut() {
                         *id = vec![key];
                     }
-                };
+                }
                 self.checked.clear();
                 if let Ok(mut second) = self.check_status_second.try_borrow_mut() {
                     *second = CheckStatus::Unchecked;
@@ -438,7 +438,7 @@ where
                         return false;
                     }
                     Kind::LayeredSecond => return false, // unreachable
-                };
+                }
             }
             Message::ClickButton(modal) => {
                 self.modal = modal;

--- a/src/select/complex/component.rs
+++ b/src/select/complex/component.rs
@@ -308,12 +308,12 @@ impl Component for Model {
                         if let Ok(mut sel) = ctx.props().selected.predefined.try_borrow_mut() {
                             *sel = None;
                         }
-                    };
+                    }
                     self.buffer_direction_items(ctx);
                 } else {
                     ctx.link().send_message(Message::ClickAll);
                     return false;
-                };
+                }
             }
             Message::ClickAddInput => {
                 if self.validate_user_input(ctx) {

--- a/src/select/searchable.rs
+++ b/src/select/searchable.rs
@@ -600,7 +600,7 @@ where
                                         CheckStatus::Unchecked
                                     };
                                     let mut item_value = item.value_txt(&txt, ctx.props().language);
-                                    if  ctx.props().sized_value { item_value = shorten_text(item.value_txt(&txt, ctx.props().language).as_str(), width, &ctx.props().font, 5); };
+                                    if  ctx.props().sized_value { item_value = shorten_text(item.value_txt(&txt, ctx.props().language).as_str(), width, &ctx.props().font, 5); }
                                     html! {
                                         <tr>
                                             <td class="searchable-select-list-checkbox">
@@ -629,7 +629,7 @@ where
                                         CheckStatus::Unchecked
                                     };
                                     let mut item_value = item.value_txt(&txt, ctx.props().language);
-                                    if ctx.props().sized_value { item_value = shorten_text(item.value_txt(&txt, ctx.props().language).as_str(), width, &ctx.props().font, 5); };
+                                    if ctx.props().sized_value { item_value = shorten_text(item.value_txt(&txt, ctx.props().language).as_str(), width, &ctx.props().font, 5); }
                                     if ctx.props().kind == Kind::Multi {
                                         html! {
                                             <tr>


### PR DESCRIPTION
## Related Issues
closes #290  
## PR Description
- Remove unnecessary Semicolon
- Replace `map_or` with ~`is_some_and` and `is_none_or`~ a simpler comparison
- Fix for `format_push_string` lint
  - Using `format!` together with `push_str` can cause unnecessary allocations compared to using `write!`.
  - For performance reference: https://play.rust-lang.org/?version=nightly&mode=release&edition=2018&gist=daed734101a8d8bc0c6a7bd811154504
