### PR TITLE
Add immutable feature to text field of `WholeList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated to Rust 2024 edition.
 - Add height to `Modal` and support HTML in `TextStyle`.
 - Add `MsgType::None` for modal and set title header when not pumpkin.
+- Added an `immutable` flag to `TextConfig` — when true, disables the associated
+  input field in the edit modal.
 
 ### Fixed
 

--- a/src/input/component.rs
+++ b/src/input/component.rs
@@ -1030,7 +1030,7 @@ where
                 match &**input_conf {
                     InputConfig::Text(config) => {
                         self.view_text(ctx, &config.ess, config.length, config.width, input_data,
-                            None, index, index == 0, false)
+                            None, index, index == 0, false, config.immutable)
                     }
                     InputConfig::Password(config) => {
                         self.view_password(ctx, &config.ess, config.width, input_data, None, index,

--- a/src/input/config.rs
+++ b/src/input/config.rs
@@ -33,6 +33,7 @@ pub struct TextConfig {
     pub width: Option<u32>,
     pub preset: Option<String>,
     pub unique: bool,
+    pub immutable: bool,
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/input/user_input.rs
+++ b/src/input/user_input.rs
@@ -60,6 +60,7 @@ where
         layer_index: usize,
         autofocus: bool,
         group: bool,
+        immutable: bool,
     ) -> Html {
         let my_index = cal_index(base_index, layer_index);
         let my_index_clone = my_index.clone();
@@ -103,6 +104,7 @@ where
             width.map_or("100%".to_string(), |w| format!("{w}px"))
         );
 
+        let is_edit_mode = ctx.props().input_id.is_some();
         html! {
             <div class={class_item}>
                 {
@@ -135,6 +137,7 @@ where
                                     autocomplete="off"
                                     oninput={oninput}
                                     maxlength={length.to_string()}
+                                    disabled={is_edit_mode && immutable}
                                 />
                                 { Self::view_explanation_msg(ctx)}
                             </>
@@ -148,6 +151,7 @@ where
                                     autofocus={autofocus}
                                     autocomplete="off"
                                     oninput={oninput}
+                                    disabled={is_edit_mode && immutable}
                                 />
                                 { Self::view_explanation_msg(ctx)}
                             </>

--- a/src/input/user_input_composite.rs
+++ b/src/input/user_input_composite.rs
@@ -294,7 +294,7 @@ where
                         // TODO: issue #111
                         <div class={class_line}>
                         </div>
-                        { self.view_text(ctx, &config.ess, config.length, config.width, child_data, Some(base_index), layer_index, false, false) }
+                        { self.view_text(ctx, &config.ess, config.length, config.width, child_data, Some(base_index), layer_index, false, false, config.immutable) }
                     </div>
                 }
             }
@@ -526,7 +526,7 @@ where
                                                                             let mut ess = config.ess.clone();
                                                                             ess.required = false;
                                                                             self.view_text(ctx, &ess, config.length, config.width, each_item,
-                                                                                Some(&row_rep_index), col_index, false, true)
+                                                                                Some(&row_rep_index), col_index, false, true, config.immutable)
                                                                         }
                                                                         InputConfig::HostNetworkGroup(config) => {
                                                                             let mut ess = config.ess.clone();

--- a/static/frontary/pumpkin/theme.css
+++ b/static/frontary/pumpkin/theme.css
@@ -1636,6 +1636,11 @@ input[type=text].frontary-input-text {
     color: var(--Text-Primary);
 }
 
+input[type=text].frontary-input-text:disabled {
+    background: var(--Transparent-Light-Grey);
+    color: var(--Dark-50);
+}
+
 input[type=text].frontary-input-text::placeholder {
     color: var(--Dark-30);
 }

--- a/static/frontary/theme.css
+++ b/static/frontary/theme.css
@@ -1631,7 +1631,7 @@ div.input-contents-item-title {
     height: 16px;
     font-weight: normal;
     font-size: 11px;
-    color: #666666;
+    color: #A9A9A9;
 }
 
 div.input-required-asterisk {
@@ -1649,6 +1649,10 @@ input[type=text].frontary-input-text {
     outline: none;
     border: 1px solid #CECECE;
     border-radius: 2px;
+}
+
+input[type=text].frontary-input-text:disabled {
+    color: #A9A9A9;
 }
 
 input[type=text].frontary-input-text::placeholder {


### PR DESCRIPTION
Close: #289

To support cases where fields should not be modified after creation, the `disabled` option was added instead of using `readonly`.
The `disabled` option was chosen to allow the application of different CSS styles compared to components pre defined with `readonly`.

With this change, the immutable property is now properly applied to the `WholeList` > `Text` field.
For fields such as IDs that should not be modified once created, the field's title can be added to `immutable_fields`, making the corresponding Text field appear as disabled only in the edit modal.
If other UI components such as Select or Checkbox require immutable support in the future, this commit can be used as a reference for further extension.

One concern is that the Edit and Create modals currently cannot be controlled separately from the outside.
The same modal is used in both cases, and for this update, the small difference was handled by adding `immutable_fields` to the `WholeList`.
However, if there is a future need for significantly different UI or behavior between the Edit and Create modals, it may be necessary to decouple the WholeList and its input modal and define separate modals for editing and creation.