### PR TITLE
Update layout to wrap lines only between words

### DIFF
--- a/static/frontary/pumpkin/theme.css
+++ b/static/frontary/pumpkin/theme.css
@@ -1104,6 +1104,8 @@ td.list-whole-head-title:hover {
 
 td.list-whole-head-title-inner-text {
     height: 30px;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 }
 
 td.list-whole-head-title-inner-sort {
@@ -1205,6 +1207,8 @@ td.list-whole-list-flat {
     vertical-align: middle;
     padding: 12px 16px;
     box-shadow: 0px -1px 0px 0px rgba(95, 104, 118, 0.24) inset;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 }
 
 td.list-whole-list-flat-more-action {

--- a/static/frontary/theme.css
+++ b/static/frontary/theme.css
@@ -1058,6 +1058,8 @@ tr.list-whole-head {
 tr.list-whole-list-flat {
     background-color: #FFFFFF;
     border-bottom: 1px solid #EEEEEE;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 }
 
 tr.list-whole-list-flat-border {
@@ -1091,6 +1093,8 @@ td.list-whole-head-title:hover {
 
 td.list-whole-head-title-inner-text {
     height: 30px;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 }
 
 td.list-whole-head-title-inner-sort {


### PR DESCRIPTION
## Related Issues
- close #297

## PR Description
- Modified styles for `.list-whole-head-inner-text` and `.list-whole-list-flat`
- Ensured content within the checkbox column is displayed in a single line