### PR TITLE
Migrate from Chrono to Jiff crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `overflow-y: auto` to `input-inner` to enhance vertical scrolling and
   layout behavior.
 - Added `UInteger`, `Vector`, `IpAddr`, `Bool` to `ValueKind`.
+- `creation_time` in `ListItem` no longer uses `DateTime<Utc>` from `chrono`; it
+  now uses `Timestamp` from `jiff`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,6 @@ test = []
 [dependencies]
 anyhow = "1"
 bincode = "1"
-chrono = { version = "0.4.35", default-features = false, features = [
-    "serde",
-    "wasmbind",
-] }
 data-encoding = "2"
 gloo-events = "0.2"
 gloo-file = "0.3"
@@ -26,6 +22,7 @@ gloo-timers = "0.3"
 gloo-utils = "0.2"
 htmlescape = "0.3"
 ipnet = { version = "2", features = ["serde"] }
+jiff = { version = "0.2", default-features = false, features = ["serde", "js"] }
 js-sys = "0.3"
 json-gettext = "4"
 num-bigint = "0.4"

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,7 +6,7 @@ use std::{
     fmt::{self, Write},
 };
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 pub use whole::{MessageType, Model as WholeList, SortColumn};
 
 use crate::{
@@ -21,7 +21,7 @@ const NUM_OF_DECIMALS_DEFAULT: usize = 2;
 pub struct ListItem {
     pub columns: Vec<Column>,
     pub sub_items: Vec<Vec<Column>>,
-    pub creation_time: Option<DateTime<Utc>>,
+    pub creation_time: Option<Timestamp>,
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/list/whole/function.rs
+++ b/src/list/whole/function.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry::Vacant;
 use std::rc::Rc;
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use yew::{Component, Context};
 
 use super::{Message, Model, SortColumn, ViewInputStatus, component::SortListKind};
@@ -165,7 +165,7 @@ where
             (Some(s.index), s.status == SortStatus::Ascending)
         });
 
-        let mut keys: Vec<(String, String, Option<DateTime<Utc>>)> = ctx
+        let mut keys: Vec<(String, String, Option<Timestamp>)> = ctx
             .props()
             .data
             .iter()


### PR DESCRIPTION
## Related Issues
- Closes #312

## PR Description
- Update dependency from Chrono to Jiff v0.2.0
  - [Comparison with other Rust datetime crates](https://github.com/BurntSushi/jiff/blob/HEAD/COMPARE.md), Jiff provides better timezone handling, DST-aware arithmetic, and an API that prevents common mistakes
  - Jiff follows a more modern datetime format approach (RFC 3339/ISO 8601 hybrid)
- Add features to Jiff configuration :
  - "serde": Enables serialization/deserialization support (equivalent to chrono's serde feature)
  - "js": Enables WASM support for browser environments (equivalent to chrono's wasmbind feature)
  - Configure Jiff with `default-features = false` to minimize binary size
    - UTC functionality is part of Jiff's core and doesn't require a feature flag
    - Only explicitly enable required features: "serde" and "js"
  - ref: [jiff v0.2.0 docs](https://docs.rs/jiff/0.2.0/jiff/#features)
- Replace DateTime with Timestamp in ListItem struct
- Update all related imports and references to use Jiff instead of Chrono

## Special Notes
- You'll need to update the project you're using to handle the new Jiff types.