### PR TITLE
Use `-` instead of `~` for range separators

### DIFF
--- a/src/input/host_network.rs
+++ b/src/input/host_network.rs
@@ -53,14 +53,14 @@ pub enum DeleteIndex {
 const DEFAULT_MAX_HEIGHT: u32 = 280;
 const EXIST_MSG: &str = "The input already exists.";
 const INVALID_INPUT_MSG: &str =
-    "Invalid input (valid examples: 10.84.1.7, 10.1.1.1 ~ 10.1.1.20, 192.168.10.0/24)";
+    "Invalid input (valid examples: 10.84.1.7, 10.1.1.1 - 10.1.1.20, 192.168.10.0/24)";
 const INVALID_INPUT_MSG_HOST: &str = "Invalid IP address";
-const INVALID_INPUT_MSG_RANGE: &str = "Invalid input (valid examples: 10.1.1.1 ~ 10.1.1.20)";
+const INVALID_INPUT_MSG_RANGE: &str = "Invalid input (valid examples: 10.1.1.1 - 10.1.1.20)";
 const MAX_NUM_MSG: &str = "The maximum number of input was reached.";
 const INPUT_ALL_NOTICE: &str =
-    "Multiple inputs possible (valid examples: 10.84.1.7, 10.1.1.1 ~ 10.1.1.20, 192.168.10.0/24)";
+    "Multiple inputs possible (valid examples: 10.84.1.7, 10.1.1.1 - 10.1.1.20, 192.168.10.0/24)";
 const INPUT_HOST_NOTICE: &str = "Multiple IP addresses possible";
-const INPUT_RANGE_NOTICE: &str = "(Input Example: 192.168.1.100 ~ 192.168.1.200)";
+const INPUT_RANGE_NOTICE: &str = "(Input Example: 192.168.1.100 - 192.168.1.200)";
 const INPUT_NETWORK_NOTICE: &str = "(Input Example: 192.168.10.0/24)";
 
 #[derive(Clone, PartialEq, Properties)]

--- a/src/ip_range_input.rs
+++ b/src/ip_range_input.rs
@@ -140,8 +140,8 @@ impl Model {
 }
 
 fn check_input(input: &str) -> Option<IpRange> {
-    if input.contains('~') {
-        input.split_once('~').and_then(|(start, end)| {
+    if input.contains('-') {
+        input.split_once('-').and_then(|(start, end)| {
             if let (Ok(start), Ok(end)) = (
                 Ipv4Addr::from_str(start.trim()),
                 Ipv4Addr::from_str(end.trim()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ pub fn parse_host_network(input: &str) -> Option<HostNetwork> {
     if Ipv4Net::from_str(input).is_ok() {
         return Some(HostNetwork::Network(input.to_string()));
     }
-    if let Some((start, end)) = input.split_once('~') {
+    if let Some((start, end)) = input.split_once('-') {
         let (start, end) = (start.trim(), end.trim());
         if let (Ok(start), Ok(end)) = (Ipv4Addr::from_str(start), Ipv4Addr::from_str(end)) {
             if start < end {
@@ -197,7 +197,7 @@ fn validate_ip_range(txt: &str, del: char) -> Option<String> {
         let (ip_start, ip_end) = (ip_start.trim(), ip_end.trim());
         if let (Ok(start), Ok(end)) = (Ipv4Addr::from_str(ip_start), Ipv4Addr::from_str(ip_end)) {
             if start < end {
-                return Some(format!("{ip_start} ~ {ip_end}"));
+                return Some(format!("{ip_start} - {ip_end}"));
             }
         }
     }
@@ -353,7 +353,7 @@ impl Ord for IpRange {
 
 impl fmt::Display for IpRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} ~ {}", self.start, self.end)
+        write!(f, "{} - {}", self.start, self.end)
     }
 }
 

--- a/src/port_range_input.rs
+++ b/src/port_range_input.rs
@@ -145,8 +145,8 @@ impl Model {
 }
 
 fn check_input(input: &str) -> Option<PortRange> {
-    if input.contains('~') {
-        input.split_once('~').and_then(|(start, end)| {
+    if input.contains('-') {
+        input.split_once('-').and_then(|(start, end)| {
             if let (Ok(start), Ok(end)) = (i64::from_str(start.trim()), i64::from_str(end.trim())) {
                 (start < end).then_some(PortRange {
                     start: Some(start),

--- a/src/select/complex/component.rs
+++ b/src/select/complex/component.rs
@@ -335,7 +335,7 @@ impl Component for Model {
                     }
                 } else {
                     self.input_wrong_msg = Some(
-                        "Invalid input (valid examples: 10.84.1.7, 10.1.1.1 ~ 10.1.1.20, 192.168.10.0/24)",
+                        "Invalid input (valid examples: 10.84.1.7, 10.1.1.1 - 10.1.1.20, 192.168.10.0/24)",
                     );
                 }
             }

--- a/src/select/complex/view.rs
+++ b/src/select/complex/view.rs
@@ -339,7 +339,7 @@ impl Model {
                                         {
                                             for networks.ranges.iter().map(|r| html! {
                                                 <>
-                                                    { r.start.clone() } { " ~ " } { r.end.clone() } <br/>
+                                                    { r.start.clone() } { " - " } { r.end.clone() } <br/>
                                                 </>
                                             })
                                         }


### PR DESCRIPTION
Closes #322

- Update parsing logic to split on `-` (using `split_once('-')`)
- Adjust validation to accept only “IP - IP” and reject “IP~IP”
- Replace all placeholders, UI strings, and examples to show hyphens