### PR TITLE
Enable CI on PR merge into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
Closes #419
- Added `pull_request` event for main branch in CI workflow
- Ensured CI runs on merge commit to catch conflicts