### PR TITLE
Respect second-layer edit state for inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed overflow in `searchable-select-list-down` CSS to remove horizontal scrollbar.
 - Fixed mini select styling for `pumpkin` feature by moving some inline colors
   to CSS, enabling proper dark/light mode integration.
+- Fixed an issue where `Add` mode was incorrectly detected as `Edit` mode if
+  `input_id` remained set after `Edit`/`Delete` actions.
 
 ### Removed
 

--- a/src/input/user_input.rs
+++ b/src/input/user_input.rs
@@ -11,7 +11,7 @@ use yew::{Component, Context, Html, events::InputEvent, html, html::TargetCast};
 
 use super::{
     InputItem, cal_index,
-    component::{InvalidMessage, Message, Model},
+    component::{InputSecondId, InvalidMessage, Message, Model},
 };
 use crate::{
     HostNetworkHtml, HostNetworkKind, InputEssential, InvalidPasswordKind as Kind, Tag, Theme,
@@ -108,8 +108,11 @@ where
             "width: {};",
             width.map_or("100%".to_string(), |w| format!("{w}px"))
         );
-
-        let is_edit_mode = ctx.props().input_id.is_some();
+        let is_edit_mode = match ctx.props().input_second_id.as_ref() {
+            Some(InputSecondId::Add) => false,
+            Some(InputSecondId::Edit(_)) => true,
+            None => ctx.props().input_id.is_some(),
+        };
         html! {
             <div class={class_item}>
                 {

--- a/src/list/whole/component.rs
+++ b/src/list/whole/component.rs
@@ -778,11 +778,13 @@ where
     fn view(&self, ctx: &Context<Self>) -> Html {
         let txt = ctx.props().txt.txt.clone();
         let onclick_add = ctx.link().callback(|_| Message::InputAdd);
-        let input_id = ctx
-            .props()
-            .input_ids
-            .try_borrow()
-            .map_or(None, |ids| ids.first().cloned());
+        let input_id = if matches!(self.view_input_status, ViewInputStatus::Edit)
+            && let Ok(ids) = ctx.props().input_ids.try_borrow()
+        {
+            ids.first().cloned()
+        } else {
+            None
+        };
         let sort_column = ctx
             .props()
             .display_info


### PR DESCRIPTION
- derived text input edit mode from `input_second_id` when present
- stopped passing `input_id` during add flows so fields stay writable

Closes #460