### PR TITLE
Add domain name list column support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added custom validation for `TextConfig`.
 - Added max length validation for `PasswordConfig`.
 - Added validations for `HostNetworkGroupConfig`.
+- Added `Column::DomainName` variant to `WholeList`.
 
 ### Changed
 

--- a/src/input/item.rs
+++ b/src/input/item.rs
@@ -1127,6 +1127,7 @@ impl From<&Column> for InputItem {
     fn from(col: &Column) -> Self {
         match col {
             Column::Text(txt) => Self::Text(TextItem::new(txt.text.to_string())),
+            Column::DomainName(domain) => Self::DomainName(DomainNameItem::new(&domain.domain)),
             Column::HostNetworkGroup(items) => {
                 let mut input = InputHostNetworkGroup::default();
                 for item in &items.host_network_group {
@@ -1191,6 +1192,7 @@ impl From<&Column> for InputItem {
                     for c in g {
                         match c {
                             Column::Text(..)
+                            | Column::DomainName(..)
                             | Column::HostNetworkGroup(..)
                             | Column::SelectSingle(..)
                             | Column::SelectMultiple(..)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,11 +93,11 @@ pub use crate::input::{
 pub use crate::ip_range_input::Model as IpRangeInput;
 pub use crate::language::Language;
 pub use crate::list::{
-    CheckboxColumn, ColWidths, Column, ComparisonColumn, DataType, DisplayInfo, FileColumn,
-    Float64Column, GroupColumn, HostNetworkGroupColumn, Kind, ListItem, MessageType, ModalDisplay,
-    NicColumn, PercentageColumn, RadioColumn, SelectMultipleColumn, SelectSingleColumn, SortColumn,
-    SortListKind, TagColumn, TextColumn, Unsigned8Column, Unsigned32Column, VecSelectColumn,
-    WholeList,
+    CheckboxColumn, ColWidths, Column, ComparisonColumn, DataType, DisplayInfo, DomainNameColumn,
+    FileColumn, Float64Column, GroupColumn, HostNetworkGroupColumn, Kind, ListItem, MessageType,
+    ModalDisplay, NicColumn, PercentageColumn, RadioColumn, SelectMultipleColumn,
+    SelectSingleColumn, SortColumn, SortListKind, TagColumn, TextColumn, Unsigned8Column,
+    Unsigned32Column, VecSelectColumn, WholeList,
 };
 pub use crate::modal::{
     AlignButton as ModalAlign, Model as Modal, MsgType as ModalType, TextStyle as ModalTextStyle,

--- a/src/list.rs
+++ b/src/list.rs
@@ -32,6 +32,11 @@ pub struct TextColumn {
 }
 
 #[derive(Clone, PartialEq)]
+pub struct DomainNameColumn {
+    pub domain: String,
+}
+
+#[derive(Clone, PartialEq)]
 pub struct HostNetworkGroupColumn {
     pub host_network_group: Vec<String>,
 }
@@ -124,6 +129,7 @@ pub struct ModalDisplay {
 #[derive(Clone, PartialEq)]
 pub enum Column {
     Text(TextColumn),
+    DomainName(DomainNameColumn),
     HostNetworkGroup(HostNetworkGroupColumn),
     SelectSingle(SelectSingleColumn),
     SelectMultiple(SelectMultipleColumn),
@@ -145,6 +151,7 @@ impl std::fmt::Display for Column {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Text(d) => write!(formatter, "{}", &d.text),
+            Self::DomainName(d) => write!(formatter, "{}", &d.domain),
             Self::HostNetworkGroup(d) => write!(formatter, "{}", d.host_network_group.join(",")),
             Self::SelectSingle(d) => {
                 if let Some((_, value)) = d.selected.as_ref() {

--- a/src/list/whole/view.rs
+++ b/src/list/whole/view.rs
@@ -404,10 +404,10 @@ where
                                     if let Some(pages_info) = self.pages_info_second.get(key) {
                                         let data = Rc::new(item.sub_items.iter().enumerate().map(|(index, item)| {
                                             // HIGHLIGHT: use the first item as the key
-                                            let key = if let Some(Column::Text(txt)) = item.first() {
-                                                txt.text.to_string()
-                                            } else {
-                                                index.to_string()
+                                            let key = match item.first() {
+                                                Some(Column::Text(txt)) => txt.text.to_string(),
+                                                Some(Column::DomainName(domain)) => domain.domain.clone(),
+                                                _ => index.to_string(),
                                             };
                                             (
                                                 key,
@@ -699,6 +699,7 @@ where
                     }
                 }
             }
+            Column::DomainName(elem) => html! { elem.domain.clone() },
             Column::HostNetworkGroup(elem) => {
                 html! {
                     for elem.host_network_group.iter().map(|elem| html! {
@@ -819,6 +820,7 @@ where
                                         for g.iter().map(|c|
                                             match c {
                                                 Column::Text(..)
+                                                | Column::DomainName(..)
                                                 | Column::HostNetworkGroup(..)
                                                 | Column::SelectSingle(..)
                                                 | Column::SelectMultiple(..)


### PR DESCRIPTION
## Related Issues
Closes: #470

## PR Description
- add `Column::DomainName` for WholeList while keeping the stored value as `String`
- keeping `domain` as `String` avoids unnecessary localization work