### PR TITLE
Fix WholeList pagination cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   in `complex-select`.
 - Fixed `SelectMini` so that changing the direction dropdown for a custom IP no
   longer inadvertently checks other custom-IP rows.
+- Fixed `WholeList` pagination cache so recalculated page info persists after
+  data updates instead of reverting to stale page numbers.
 
 ### Changed
 

--- a/src/list/whole/function.rs
+++ b/src/list/whole/function.rs
@@ -105,6 +105,7 @@ where
                     };
                 }
             }
+            self.pages_info = Some(*info);
         }
     }
 


### PR DESCRIPTION
Close #540

- Fix `WholeList` pagination cache so page counts update immediately after deletions